### PR TITLE
Adding rosplan_rqt to meta package

### DIFF
--- a/rosplan/package.xml
+++ b/rosplan/package.xml
@@ -14,6 +14,7 @@
 	<run_depend>rosplan_planning_system</run_depend>
 	<run_depend>rosplan_knowledge_base</run_depend>
 	<run_depend>rosplan_demos</run_depend>
+	<run_depend>rosplan_rqt</run_depend>
 
 	<export>
 		<metapackage/>


### PR DESCRIPTION
Not sure if this is supposed to be in there but it is currently missing and hence not install when installing `ros-indigo-rosplan`. Please, just reject if it should not be installed by default.
