### PR TITLE
Fixing planning action server

### DIFF
--- a/rosplan_planning_system/include/rosplan_planning_system/PlanningSystem.h
+++ b/rosplan_planning_system/include/rosplan_planning_system/PlanningSystem.h
@@ -66,6 +66,9 @@ namespace KCL_rosplan {
 		size_t dispatch_attempts;
 		int max_dispatch_attempts;
 
+		void readParams();
+		void preemptCallback();
+
 	public:
 		PlanningSystem(ros::NodeHandle& nh);
 		virtual ~PlanningSystem();
@@ -76,7 +79,7 @@ namespace KCL_rosplan {
 		bool runPlanningServerDefault(std_srvs::Empty::Request &req, std_srvs::Empty::Response &res);
 		bool runPlanningServerParams(rosplan_dispatch_msgs::PlanningService::Request &req, rosplan_dispatch_msgs::PlanningService::Response &res);
 		void runPlanningServerAction(const rosplan_dispatch_msgs::PlanGoalConstPtr& goal);
-		bool runPlanningServer(std::string domainPath, std::string problemPath, std::string dataPath, std::string plannerCommand);
+		bool runPlanningServer(std::string domainPath="", std::string problemPath="", std::string dataPath="", std::string plannerCommand="");
 
 
 		/* knowledge */


### PR DESCRIPTION
- Adding preemption for planning action server.
- Allowing to only specify parts of the parameters or none when calling the action or service where the rest is taken from the parameter server. Before all the parameters like `planning_command` had to be defined when calling the action. Now they are taken from the parameter server and overridden if they are specified in the goal.
