### PR TITLE
Removing mongodb from launch files.

### DIFF
--- a/rosplan_knowledge_base/launch/rosplan_knowledge_base.launch
+++ b/rosplan_knowledge_base/launch/rosplan_knowledge_base.launch
@@ -6,11 +6,11 @@
 	<node name="rosplan_knowledge_base" pkg="rosplan_knowledge_base" type="knowledgeBase" respawn="false" output="screen">
 	</node>
 
-	<!-- scene database (MongoDB) -->
+	<!-- scene database (MongoDB)
 	<node name="rosplan_scene_base" pkg="mongodb_store" type="mongodb_server.py" respawn="false" output="screen">
 	    <param name="database_path" value="$(find rosplan_config)/knowledge_base/mongoDB" />
 	</node>
 	<node name="rosplan_scene_message_store" pkg="mongodb_store" type="message_store_node.py" respawn="false" output="screen">
-	</node>
+	</node -->
 
 </launch>

--- a/rosplan_knowledge_base/src/KnowledgeBase.cpp
+++ b/rosplan_knowledge_base/src/KnowledgeBase.cpp
@@ -481,9 +481,9 @@ int main(int argc, char **argv)
 	ros::Subscriber missionFilterSub = n.subscribe("/kcl_rosplan/plan_filter", 100, &KCL_rosplan::PlanFilter::missionFilterCallback, &kb.plan_filter);
 
 	// wait for and clear mongoDB 
-	ROS_INFO("KCL: (KB) Waiting for MongoDB");
-	ros::service::waitForService("/message_store/delete",-1);
-	system("mongo message_store --eval \"printjson(db.message_store.remove())\"");
+//	ROS_INFO("KCL: (KB) Waiting for MongoDB");
+//	ros::service::waitForService("/message_store/delete",-1);
+//	system("mongo message_store --eval \"printjson(db.message_store.remove())\"");
 
 	ROS_INFO("KCL: (KB) Ready to receive");
 	ros::spin();

--- a/rosplan_planning_system/launch/planning_system_knowledge.launch
+++ b/rosplan_planning_system/launch/planning_system_knowledge.launch
@@ -19,12 +19,12 @@
 	<node name="rosplan_knowledge_base" pkg="rosplan_knowledge_base" type="knowledgeBase" respawn="false" output="screen">
 	</node>
 
-	<!-- scene database (MongoDB) -->
+	<!-- scene database (MongoDB)
 	<node name="rosplan_scene_database" pkg="mongodb_store" type="mongodb_server.py" respawn="false" output="log">
 	    <param name="database_path" value="$(find rosplan_config)/knowledge_base/mongoDB" />
 	</node>
 	<node name="rosplan_scene_message_store" pkg="mongodb_store" type="message_store_node.py" respawn="false" output="log">
-	</node>
+	</node -->
 
 
 	<!-- planning system -->


### PR DESCRIPTION
Also commented the two lines that drop the message store when knowledge base is started.

Mongodb is currently only used in the [mapping](https://github.com/LCAS/ROSPlan/tree/indigo-devel/rosplan_interface_mapping) and [movebase](https://github.com/LCAS/ROSPlan/tree/indigo-devel/rosplan_interface_movebase) interfaces but not in the knowledge base. The only thing that interacted with mongodb was the line that dropped the message store on start-up. No other operations are performed. Hence, it is not necessary to start mongodb with most of the launch files except for the `interfaced_planning_system.launch` in `rosplan_planning_systems`. 

Even the use of mongodb in the mapping and movebase interfaces is questionable because the `message_store` they use was deleted everytime the knowledge base was started. Therefore, there was no persistent data storage any way. I guess the mongodb was just used to store the map?! See issue https://github.com/KCL-Planning/ROSPlan/issues/32

Ping @pet1330 because I cannot assign him to make him aware of this.
